### PR TITLE
chore: strengthen audit skills, fix privacy leaks they uncovered

### DIFF
--- a/.claude/skills/audit-architecture/SKILL.md
+++ b/.claude/skills/audit-architecture/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit-architecture
-description: Use when auditing Sickbay's monorepo architecture for boundary violations, dependency order problems, bundled-deps drift, or cross-package import issues. Run before merging large feature branches or after adding new packages.
+description: Use when auditing Sickbay's monorepo architecture for boundary violations, dependency order problems, bundled-deps drift, cross-package import issues, workspace registration gaps, fixtures/docs isolation, tsconfig drift, or release-workflow invariants. Run before merging large cross-package branches, after adding new packages, or before a major release.
 ---
 
 # Audit: Monorepo Architecture
 
-Dispatch the `monorepo-architect` agent to review structural integrity across all Sickbay packages.
+Dispatch the `monorepo-architect` agent to review structural integrity across all Sickbay packages and apps. This audit is about the *shape* of the monorepo, not the correctness of any single package.
 
 ## Checklist
 
@@ -15,15 +15,16 @@ Dispatch the `monorepo-architect` agent to review structural integrity across al
 
 - Search `apps/web/src/` for any `from 'sickbay-core'` that is NOT `import type`
 - Search for any `require('sickbay-core')` in web
-- Check `apps/web/src/lib/constants.ts` — constants that needed core values should be duplicated here (not imported)
+- Check `apps/web/src/lib/constants.ts` — constants that needed core values are duplicated here (not imported)
 
 ### 2. Dependency Order
 
-The enforced build order is: `packages/core` → `apps/cli` → `apps/web`
+The enforced build order is: `packages/core` → `apps/cli` → `apps/web`.
 
-- `packages/core` must not import from `apps/cli` or `apps/web`
-- `apps/cli` must not import from `apps/web`
-- Check `turbo.json` pipeline — `dependsOn` must reflect this order
+- `packages/core` must not import from `apps/cli`, `apps/web`, or `apps/docs`
+- `apps/cli` must not import from `apps/web` or `apps/docs`
+- `apps/web` and `apps/docs` must not import from each other
+- Check `turbo.json` pipeline — `dependsOn` reflects this order
 - Check `pnpm-workspace.yaml` — no circular workspace references
 
 ### 3. Bundled-Deps Mirror Invariant
@@ -33,36 +34,127 @@ The enforced build order is: `packages/core` → `apps/cli` → `apps/web`
 - Run `pnpm check:bundled-deps` — must pass with zero drift
 - Compare `packages/core/package.json` dependencies vs `apps/cli/package.json` dependencies manually
 - Check `apps/cli/knip.config.ts` `ignoreDependencies` list matches core's deps exactly
+- If a new package is added that also bundles core, update `scripts/check-bundled-deps.mjs` to include it
 
 ### 4. Circular Dependencies Within Packages
 
 - Run `pnpm --filter sickbay-core exec madge --circular src/` — must return no cycles
 - Run `pnpm --filter sickbay exec madge --circular src/` — same
-- Pay attention to `src/integrations/` — runners must not import from each other
+- Pay attention to `src/integrations/` — runners must not import from each other. Same for `src/advisors/`
 
 ### 5. Type Export Discipline
 
 - `packages/core/src/index.ts` — check what's exported. Types should be exported; internal implementation should not leak
-- `apps/cli` imports from `sickbay-core` — verify these are workspace imports, not relative path hacks
+- `apps/cli` imports from `sickbay-core` — verify these are workspace imports, not relative path hacks (e.g. `../../packages/core/src/...`)
+- Internal utilities (`utils/suppress`, `utils/dep-tree`) should not be in the public export unless explicitly needed by cli
 
-### 6. New Package Registration
+### 6. Documentation Site (`apps/docs`)
+
+VitePress site deployed to `nebulord-dev.github.io/sickbay` via `.github/workflows/docs.yml`. Easy to forget because it's not built by the root `pnpm build`.
+
+- `apps/docs` is in `pnpm-workspace.yaml`
+- Excluded from `turbo.json` default build pipeline — docs deploy separately, and bundling it into the root build slows cold builds
+- Docs workflow triggers are correct (main-only deploy or PR preview)
+- **Content-coupling check:** if a CLI flag, config option, or scoring rule changed in this branch, verify the corresponding `apps/docs/commands/*.md` or `apps/docs/guide/*.md` was updated. The `sync-docs` skill can generate a draft; architecture audit verifies the coupling isn't broken
+
+### 7. Fixtures Workspace Isolation
+
+`fixtures/` is a separate pnpm workspace — by design, so intentionally-broken dependencies don't pollute Sickbay's own dep tree.
+
+- Fixtures has its own `pnpm-lock.yaml` — MUST NOT be merged into root lockfile
+- Fixtures MUST NOT be in root `pnpm-workspace.yaml` (it has its own)
+- Fixtures MUST NOT be in `turbo.json` pipeline — fixtures should only be scanned by Sickbay, never built as part of the project
+- `fixtures/packages/*/.sickbay/` cache directories — intentionally tracked for deterministic snapshot tests; check `.gitignore` handling
+- New fixture added → `fixtures/README.md` documents what intentional issues it contains
+
+### 8. Snapshot Tests Workspace (`tests/snapshots/`)
+
+Standalone test directory with its own `tsconfig.json` and `vitest.config.ts`. Runs fixtures through the built CLI and compares JSON output to committed snapshots.
+
+- Must treat fixtures as black-box inputs — no direct imports from `fixtures/`
+- Snapshot diffs flag real regressions — never update snapshots to make tests pass without explaining why
+- `pnpm test:snapshots` is in CI; this audit verifies the workspace config is still correct
+
+### 9. TypeScript Configuration
+
+- `tsconfig.base.json` is shared. Each package extends it via `{ "extends": "../../tsconfig.base.json" }` (or the right relative path)
+- Per-package overrides that silently loosen strictness (`noImplicitAny: false`, `strict: false`, `skipLibCheck` added locally when it's already in base) are suspect — either fix the root cause or document why
+- If any package uses TypeScript **project references** (`"references": []`), the whole system must be consistent — partial adoption causes mysterious build-order issues where one package "can't see" another's types
+
+### 10. Release Workflow Invariant
+
+Only `sickbay` (the CLI) publishes to npm via semantic-release. Core and web are private, and this must not change without a plan.
+
+- `packages/core/package.json` must stay `"private": true` — publishing it breaks the bundled-deps invariant (users would install two copies)
+- `apps/web/package.json` must stay `"private": true`
+- `apps/docs/package.json` must stay `"private": true`
+- `.releaserc.json` only bumps `apps/cli/package.json` for version changes
+- If a new publishable package is proposed, that's a release-strategy decision, not a routine change
+
+### 11. New Package Registration
 
 If any new package was added since last audit:
-- Is it in `pnpm-workspace.yaml`?
-- Is it in `turbo.json` with correct `dependsOn`?
-- Does it have its own `tsconfig.json` extending `tsconfig.base.json`?
-- Does `scripts/check-bundled-deps.mjs` need updating?
+
+- In `pnpm-workspace.yaml`?
+- In `turbo.json` with correct `dependsOn`?
+- Own `tsconfig.json` extending `tsconfig.base.json`?
+- Own `vitest.config.ts` (if tested)?
+- `scripts/check-bundled-deps.mjs` updated if the new package bundles core?
+- `.releaserc.json` updated if the new package publishes?
+
+### 12. `.sickbay/` Cache Directories
+
+Sickbay writes to `.sickbay/` inside any analyzed project, including its own repo.
+
+- Root `.gitignore` includes `.sickbay/` (so Sickbay's own scans don't pollute git)
+- Fixtures' `.sickbay/` caches are currently tracked — intentional for deterministic snapshot tests
+- No cache files accidentally committed in CLI/core/web packages
+
+## War Stories
+
+Past architectural bugs that this audit exists to prevent from recurring. Each entry is a real failure mode — treat as worked examples of what goes wrong:
+
+- **Web bundling Node.js modules** — before the `import type`-only rule was enforced, `apps/web` pulled `execa` and `child_process` into the browser bundle via a single value import from core. Vite build succeeded but runtime crashed on `fs is not defined` in production. Fix: `apps/web/src/lib/constants.ts` duplicates values; value imports from core flagged at review.
+- **Cross-platform path bugs (silent)** — 19 call sites used `fullPath.replace(projectRoot + '/', '')` for years. Linux CI never caught it. On Windows, the literal `/` didn't match `\`, so paths came out unchanged. Reports for Windows users had absolute paths with usernames for the entire project's history. Fix: `relativeFromRoot()` helper in core, Windows in the test matrix.
+- **Bundled-deps drift** — a runtime dep was removed from core without updating `apps/cli/package.json`. The published npm version crashed on first `require()` because the bundled code referenced a package that wasn't installed. Fix: `scripts/check-bundled-deps.mjs` runs in CI.
+- **In-house dep graph viz** — an early dashboard version shipped a bespoke dep graph component that was slower and worse than dedicated tools. Replaced with a link to Node Modules Inspector. Lesson: don't reinvent visualization; link out.
+- **Fixtures leaking into root build** — at one point fixtures were accidentally registered in the root `pnpm-workspace.yaml`, which pulled their intentionally-broken deps into the root lockfile and caused `pnpm install` to fail on fresh clones. Fix: fixtures isolated as a separate workspace with its own lockfile.
+
+## Key Files
+
+```
+turbo.json                        # Pipeline dependency order
+pnpm-workspace.yaml               # Workspace registration (no fixtures)
+tsconfig.base.json                # Shared compiler settings
+packages/core/package.json        # Private, dependency source-of-truth
+apps/cli/package.json             # Must mirror core's runtime deps
+apps/cli/knip.config.ts           # ignoreDependencies mirror
+apps/cli/tsdown.config.ts         # deps.alwaysBundle — the bundling invariant
+apps/web/src/lib/constants.ts     # Browser-safe duplicates from core
+scripts/check-bundled-deps.mjs    # CI guardrail
+.releaserc.json                   # Publishing scope — CLI only
+.github/workflows/                # ci.yml, publish.yml, docs.yml
+```
+
+## Output Format
+
+Dispatched reviewer should report findings as:
+
+```
+[Severity: High|Medium|Low] path/to/file:123 (or <package boundary>)
+What's wrong: <one-line description>
+Why it matters: <impact on build, release, or runtime>
+Suggested fix: <concrete change>
+```
 
 ## How to Run
 
-```
-Use the monorepo-architect agent. Provide it this checklist and the current
-state of: turbo.json, pnpm-workspace.yaml, packages/core/package.json,
-apps/cli/package.json, apps/cli/knip.config.ts, apps/web/src/lib/constants.ts
-```
+Dispatch the `monorepo-architect` agent. Provide it this checklist and the current state of: `turbo.json`, `pnpm-workspace.yaml`, `packages/core/package.json`, `apps/cli/package.json`, `apps/cli/knip.config.ts`, `apps/web/src/lib/constants.ts`, `.releaserc.json`.
 
-## Known Historical Issues
+First action: run `pnpm check:bundled-deps`. Then walk the checklist, citing war stories when a finding maps to a recurring class of bug.
 
-- Web constants: `apps/web/src/lib/constants.ts` was created specifically to avoid importing values from core. If you see score thresholds or category weights duplicated there, that's intentional — not a bug.
-- Windows path handling: any code computing relative paths must use `relativeFromRoot()` from `core/src/utils/file-helpers.ts`, never string replace with `/`.
-- The bundled-deps mirror is structural and unavoidable while core is private and sickbay ships as one package. Don't "fix" it by making core public.
+## Related Audits
+
+- Findings in §1 (boundary violations) → run **audit-web**
+- Findings in §3 (bundled-deps drift) → run **audit-cli**
+- Findings in §6 (docs coupling) → run `/sync-docs`

--- a/.claude/skills/audit-cli/SKILL.md
+++ b/.claude/skills/audit-cli/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit-cli
-description: Use when auditing apps/cli for Ink component issues, Commander flag edge cases, bundled-deps drift, TUI hook correctness, or web server security problems.
+description: Use when auditing apps/cli for Ink component issues, Commander flag edge cases, bundled-deps drift, TUI hook correctness, subcommand safety (especially `fix` which writes to user files), web server security, child process cleanup, or piped-stdin behaviour. Run before merging any change that touches apps/cli/.
 ---
 
 # Audit: apps/cli
 
-The published `sickbay` package. Audit for correctness, robustness, and the bundling invariant that keeps it installable.
+The published `sickbay` package. Audit for correctness, robustness, the bundling invariant that keeps it installable, and every subcommand's blast radius — `fix` modifies user code, so the bar is high.
 
 ## Checklist
 
@@ -35,51 +35,153 @@ Review `src/components/tui/hooks/`:
 - **`useSickbayRunner.ts`** — manages scan state. Can a new scan start while one is in progress? What's the behaviour if `runSickbay()` throws?
 - **`useTerminalSize.ts`** — SIGWINCH handler must be removed on cleanup
 
-### 4. Commander Setup
+### 4. Commander Setup (`src/index.ts`)
 
-Review `src/index.ts`:
+- All flags validated before running the scan (e.g., `--path` pointing to a non-existent directory)
+- `--checks` with an invalid check ID fails gracefully with the list of valid IDs
+- `--json` suppresses all non-JSON output, including spinners and banners
+- Exit codes correct (0 = success, non-zero = error — CI depends on this)
+- Subcommand flag collisions — e.g. does `--json` work consistently across `scan`, `diff`, `stats`?
 
-- Are all flags validated before running the scan? (e.g., `--path` pointing to a non-existent directory)
-- Does `--checks` with an invalid check ID fail gracefully?
-- Does `--json` suppress all non-JSON output, including spinners and banners?
-- Are exit codes correct? (0 = success, non-zero = error — CI depends on this)
+### 5. Subcommand Coverage
 
-### 5. Web Server (`src/commands/web.ts`)
+Each subcommand has its own audit surface. Don't stop at `scan` + `--web`.
+
+#### `fix` — **highest-risk command** (`src/commands/fix.ts`, `src/components/FixApp.tsx`)
+
+Writes to user files. Every failure mode matters.
+
+- **Dry-run / preview** — is there one? The default mode should show diffs before committing, or require an explicit `--write` flag
+- **Git-cleanliness preflight** — refuses to run (or warns loudly) on a dirty working tree. Otherwise users can't undo a bad fix
+- **Atomic writes** — partial writes on crash leave the user's code in a half-edited state. Writes must be all-or-nothing (temp file + rename)
+- **Idempotency** — running `fix` twice on the same project produces the same result as running it once. If the second run re-applies already-applied fixes, that's a bug
+- **Scope confinement** — only modifies files inside the project root. Never follows symlinks out of the tree. Never touches `.git/`, `node_modules/`, or other ignored paths
+- **Binary / generated files** — skipped. Applying text fixes to a `.png` corrupts it silently
+
+#### `init` (`src/commands/init.ts`)
+
+Writes `sickbay.config.ts` to the user's project.
+
+- **Overwrite protection** — refuses or prompts if the file exists
+- **Template correctness** — generated config imports types from `sickbay-core`, not internal paths
+- **No network side-effects** — init should be offline-safe
+
+#### `claude` + `services/ai.ts`
+
+AI integration inside the CLI, distinct from the web dashboard's AI.
+
+- API key sourced from `ANTHROPIC_API_KEY` env var, never prompted to stdin (would be captured by piping)
+- Missing key produces a clear error, not a crash from the SDK
+- Streaming output works with Ink without tearing or clobbering the UI
+- Rate limit / offline errors become friendly messages, not raw SDK stacks
+- Prompt injection: report content is user-controlled — system prompt must constrain the AI's trust in that content
+
+#### `doctor` (`src/commands/doctor.ts` — largest subcommand at 11KB)
+
+Environment diagnostics.
+
+- Each diagnostic fails independently — one failure doesn't skip the rest
+- No false positives for optional tools (e.g. don't flag "git not found" if the project doesn't use git)
+- Output is actionable — `git not found — install from https://git-scm.com` beats bare `git not found`
+
+#### `diff`, `stats`, `trend`, `badge`
+
+- All read `.sickbay/history.json` or `.sickbay/last-report.json` — handle missing / malformed files gracefully, don't crash
+- `badge` outputs SVG — every user-controlled string (project name, score) must be XML-escaped to prevent SVG injection
+- `trend` / `diff` — compare reports from different Sickbay versions. Handle schema differences without crashing
+
+### 6. Web Server (`src/commands/web.ts`)
 
 The `--web` flag starts an HTTP server. Review for:
 
-- **Path traversal** — does the static file server restrict to `dist/` only? Can `GET /../../../etc/passwd` reach the filesystem?
-- **Port handling** — if port 3030 is in use, does it find the next free port gracefully?
-- **Probe/listen host parity** — does the free-port probe bind to the same host as the real `server.listen()`? Mismatches (e.g. default `::` probe vs. `127.0.0.1` real bind) can produce false "port free" results on macOS because IPv4 and IPv6 loopback sockets are independent. Don't trust the fallback logic exists — **verify it actually fires** end-to-end: hold a port on `127.0.0.1` with a real server, call `serveWeb(report, heldPort)`, assert the returned URL uses a different port.
-- **Listen error handler** — every `http.Server` / `net.Server` must have an `.on('error', ...)` / `.once('error', ...)` listener attached **before** `server.listen()` is called. An unhandled `'error'` event on a Server EventEmitter crashes the process with a raw Node stack trace (e.g. on EADDRINUSE, EACCES) instead of producing a graceful promise rejection that the Ink error phase can render. This is a different failure mode from unhandled promise rejections — grep for every `.listen(` call in the package and confirm each has a sibling error listener.
-- **Server shutdown** — is the server closed on SIGINT/SIGTERM, or does it leave orphaned processes? On listen failure, are the SIGINT/SIGTERM handlers unregistered so they don't leak across retries?
-- **Report endpoint** — `GET /sickbay-report.json` serves the in-memory report. Verify it sets `Content-Type: application/json` and doesn't expose any other data
+- **Path traversal** — the static file server restricts to `dist/` only. `GET /../../../etc/passwd` must not reach the filesystem
+- **Port handling** — if port 3030 is in use, it finds the next free port gracefully
+- **Probe/listen host parity** — the free-port probe binds to the same host as the real `server.listen()`. Mismatches (e.g. default `::` probe vs. `127.0.0.1` real bind) produce false "port free" results on macOS because IPv4 and IPv6 loopback sockets are independent. Don't trust the fallback logic exists — verify it fires end-to-end: hold a port on `127.0.0.1` with a real server, call `serveWeb(report, heldPort)`, assert the returned URL uses a different port
+- **Listen error handler** — every `http.Server` / `net.Server` has an `.on('error', ...)` / `.once('error', ...)` listener attached **before** `server.listen()` is called. An unhandled `'error'` event on a Server EventEmitter crashes the process with a raw Node stack trace (e.g. on EADDRINUSE, EACCES) instead of producing a graceful promise rejection the Ink error phase can render. Grep every `.listen(` call in the package and confirm each has a sibling error listener
+- **CORS on report endpoint** — `/sickbay-report.json` should set `Access-Control-Allow-Origin` only to the dashboard's own origin, not `*`. The dashboard is served by the same process, so same-origin suffices
+- **Server shutdown** — the server closes on SIGINT/SIGTERM and doesn't leave orphaned processes. On listen failure, SIGINT/SIGTERM handlers are unregistered so they don't leak across retries
+- **Report endpoint content type** — `GET /sickbay-report.json` sets `Content-Type: application/json` and exposes nothing else
 
-### 6. Exit Codes and Error Handling
+### 7. Child Process Cleanup
 
-- Does an unhandled rejection in a check crash the whole CLI, or is it contained?
-- When `--json` is used, does an error produce valid JSON on stderr and a non-zero exit?
-- Does the process always exit cleanly, even after the Ink UI renders? (Ink can sometimes leave the process hanging)
+Scans spawn knip, madge, jscpd, depcheck, and other tools via execa in core. The CLI owns the process lifecycle.
 
-### 7. Update Check (`src/lib/update-check.ts`)
+- On SIGINT mid-scan, are all spawned child processes killed? Orphaned node processes after Ctrl-C is a real failure mode users notice
+- Does the Ink app unmount cleanly so the terminal isn't left broken (cursor hidden, alt-screen active, stdin in raw mode)?
+- Does `useSickbayRunner` abort in-flight scans when the component unmounts mid-scan?
 
-- Is the update check non-blocking? It must not delay the scan
-- Does it fail silently when offline or when npm registry is unreachable?
-- Is the result cached? (Should not hit npm on every run)
+### 8. Non-TTY / Piped Stdin
+
+Ink and terminal libraries behave oddly when stdin isn't a TTY.
+
+- `sickbay --json | jq` — CLI detects non-TTY and skips the interactive UI entirely, outputting pure JSON
+- `sickbay < /dev/null` — doesn't hang waiting for input
+- `sickbay --web` inside a CI runner — doesn't try to `open` a browser when `CI=true`
+
+### 9. History & Cache Files (`lib/history.ts`)
+
+`history.ts` writes three files into the analyzed project's `.sickbay/` directory: `history.json` (trend data), `last-report.json` (latest scan), and `dep-tree.json` (dep graph snapshot). All three are CLI-owned outputs derived from core.
+
+- Two parallel scans of the same project don't clobber each other's writes (atomic write — temp file + rename, not read-modify-write)
+- Malformed / truncated `history.json` — next scan recovers (treats as empty history), not crash
+- Unbounded growth of `history.json` — retention policy or cap on entries?
+- `dep-tree.json` is rewritten every scan (no cache-hit check). Verify the write is atomic so a crashed scan can't leave a truncated JSON blob on disk
+- Schema migration — if the tree or history shape changes between versions, stale files from an older install must not crash the new reader
+- `.sickbay/` lives inside the analyzed project; verify the root `.gitignore` excludes the files that shouldn't travel (it does for `dep-tree.json`)
+
+### 10. Update Check (`src/lib/update-check.ts`)
+
+- Non-blocking — must not delay the scan
+- Fails silently when offline or when npm registry is unreachable
+- Result is cached — should not hit npm on every run
+
+### 11. Exit Codes and Error Handling
+
+- Unhandled rejection in a check doesn't crash the whole CLI — it's contained
+- With `--json`, errors produce valid JSON on stderr and a non-zero exit
+- Process always exits cleanly, even after Ink renders. Ink occasionally leaves the event loop alive
 
 ## Key Files
 
 ```
 apps/cli/src/
-├── index.ts                    # Commander entry — flags, validation, exit codes
-├── commands/web.ts             # HTTP server — path traversal, port handling
-├── components/App.tsx          # Root Ink component — phases, error handling
-├── components/tui/
-│   ├── TuiApp.tsx              # TUI root — keyboard, layout
-│   └── hooks/                  # useFileWatcher, useGitStatus, useSickbayRunner
-└── lib/update-check.ts         # Non-blocking update notifications
+├── index.ts                       # Commander entry — flags, validation, exit codes
+├── commands/
+│   ├── fix.ts, init.ts            # High-risk: modify user state
+│   ├── web.ts                     # HTTP server — traversal, port handling, error listeners
+│   ├── claude.ts                  # CLI AI integration
+│   ├── doctor.ts, diff.ts         # Large diagnostic/comparison commands
+│   └── stats.ts, trend.ts, badge.ts
+├── components/
+│   ├── App.tsx, FixApp.tsx        # Root + fix-specific phases
+│   └── tui/hooks/                 # useFileWatcher, useGitStatus, useSickbayRunner
+├── services/ai.ts                 # AI service — key sourcing, prompts
+└── lib/
+    ├── history.ts                 # Trend history — atomic writes, retention
+    ├── update-check.ts            # Non-blocking update notification
+    ├── issue-grouping.ts          # Grouping stability
+    └── resolve-package.ts         # Symlink handling
 ```
+
+## Output Format
+
+Dispatched reviewer should report findings as:
+
+```
+[Severity: High|Medium|Low] path/to/file.ts:123
+What's wrong: <one-line description>
+Why it matters: <impact on users or maintainers>
+Suggested fix: <concrete change>
+```
+
+Skip style issues entirely. Prioritize in this order: bundled-deps drift → `fix` safety → web server security → child-process cleanup → TUI hook cleanup → everything else.
 
 ## How to Run
 
-Dispatch a `feature-dev:code-reviewer` agent. Focus it on the bundled-deps invariant first (run `pnpm check:bundled-deps`), then the web server security section, then TUI hook cleanup. Skip style issues entirely.
+Dispatch a `feature-dev:code-reviewer` agent. First action: run `pnpm check:bundled-deps` and surface the result. Then work through the subcommand checklist, `fix` first.
+
+## Related Audits
+
+- Changes to `apps/cli/src/commands/web.ts` → cross-check **audit-web** for CORS / CSP contract
+- Changes to `apps/cli/package.json` dependencies → run **audit-architecture** (bundled-deps invariant)
+- Changes to report rendering or types consumed → run **audit-core** (upstream source of truth)

--- a/.claude/skills/audit-core/SKILL.md
+++ b/.claude/skills/audit-core/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit-core
-description: Use when auditing packages/core for check runner correctness, BaseRunner contract violations, cross-platform path bugs, scoring edge cases, or error handling gaps in integrations.
+description: Use when auditing packages/core for check runner correctness, advisor contract, config safety, suppress-rule correctness, cross-platform path bugs, scoring edge cases, report privacy leaks, or error handling gaps in integrations. Run before merging any change that touches packages/core/.
 ---
 
 # Audit: packages/core
 
-Deep audit of the analysis engine. Focus on correctness and robustness — this is what Sickbay runs against user projects.
+Deep audit of the analysis engine. Focus on correctness, robustness, and what gets leaked into reports — this is what Sickbay runs against user projects, and reports are shared via URL and uploaded to Anthropic when AI is enabled.
 
 ## Checklist
 
@@ -18,7 +18,16 @@ Every runner in `src/integrations/` must correctly implement `BaseRunner`. Check
 - `isApplicable()` is used for I/O-based filtering only. Cheap pre-filters use declarative `applicableRuntimes` / `applicableFrameworks` fields
 - Runners that call external tools (knip, madge, jscpd, etc.) handle tool-not-found gracefully — the tool may not be installed
 
-### 2. Framework/Runtime Scoping
+### 2. Advisor Contract (src/advisors/)
+
+Parallel subsystem to integrations — advisors generate best-practice recommendations rather than pass/fail checks. Easy to miss because they're less trafficked. Check:
+
+- Each advisor extends `BaseAdvisor` and handles the no-config / no-source case cleanly
+- Framework detection logic must match the integrations' detection — if `react-best-practices.ts` uses a different detector than `react-perf.ts`, one will fire where the other doesn't
+- Advisors must not mutate project files. Recommendations go into the report; nothing on disk
+- **Duplicate recommendation risk**: if the same practice is surfaced both as an integration issue and an advisor recommendation, the user sees it twice. Spot-check that advisors don't shadow integration output
+
+### 3. Framework/Runtime Scoping
 
 Misscoped runners silently skip checks or run them on the wrong projects.
 
@@ -27,15 +36,15 @@ Misscoped runners silently skip checks or run them on the wrong projects.
 - Runners for `['react', 'next']` must not run on plain Node APIs
 - Check `src/utils/detect-project.ts` — is framework detection reliable? Edge cases: projects with multiple frameworks, projects with no `package.json`
 
-### 3. Cross-Platform Path Handling
+### 4. Cross-Platform Path Handling
 
-This has caused silent Windows failures historically (see `docs/audit-2026-04-07.md`).
+This has caused silent Windows failures historically.
 
 - Search for any `path.join` or `fullPath.replace(projectRoot + '/', '')` patterns — these break on Windows
 - All relative path computation must use `relativeFromRoot()` from `src/utils/file-helpers.ts`
 - Test files that mock `fs` and compare forward-slash paths must also mock `path` to use `path.posix`
 
-### 4. Scoring Edge Cases
+### 5. Scoring Edge Cases
 
 Review `src/scoring.ts`:
 
@@ -44,8 +53,9 @@ Review `src/scoring.ts`:
 - Score of `NaN` or `Infinity` would corrupt the web dashboard and JSON output
 - Category weight sum must equal 1.0 — verify `CATEGORY_WEIGHTS`
 - Thresholds: 80+ = green, 60–79 = yellow, <60 = red — are these applied consistently everywhere?
+- **Suppress interaction**: when users suppress issues, does the category score rise (issues effectively removed) or stay the same (suppressed but still counted)? Whichever the behaviour is, it must be consistent across report, CLI summary, and web dashboard
 
-### 5. Runner Orchestration
+### 6. Runner Orchestration
 
 Review `src/runner.ts`:
 
@@ -54,7 +64,7 @@ Review `src/runner.ts`:
 - Timeout handling — is there a timeout per check? A hung child process could stall the entire scan
 - The `checks` option (subset of check IDs) — does it correctly filter without breaking unrelated checks?
 
-### 6. Error Handling in Integrations
+### 7. Error Handling in Integrations
 
 Pick 5 integrations at random and verify:
 
@@ -64,26 +74,95 @@ Pick 5 integrations at random and verify:
 - Are child process errors (ENOENT, EPERM) caught and surfaced as issues, not crashes?
 - **Parser robustness for structured tool output:** do parsers filter degenerate entries before producing issues? Common examples: `current === latest` (pnpm can report unchanged entries when catalogs drift), missing version fields, pre-release-only diffs. Do version comparison helpers (`getUpdateType` and friends) check **every** semver segment, not just the first differing one? A fallthrough in a 2-segment compare produces silently-wrong classifications (e.g. `4.1.3 → 4.1.3` labeled as a "patch update") that surface as confusing UI.
 
-### 7. Test Coverage
+### 8. Config Safety (src/config.ts)
+
+`sickbay.config.ts` is user-authored TypeScript, loaded at runtime. Treat it as a trust boundary — the user trusts their own config but shouldn't get a raw stack trace when it's broken.
+
+- How is the config loaded (dynamic `import()`, jiti, vm sandbox)? Whichever mechanism, errors at load time must become a readable message, not a raw Node stack
+- Validation of shape/types — missing required fields, wrong types, wrong literal values (e.g. unknown check ID in `checks: [...]`) must fail with a clear validation error, not silently revert to defaults
+- What happens on `--help` or `--version`? Config loading should be lazy — don't execute user TS just to print help
+- Path normalization inside the config (e.g. `ignore: ['src/**']`) must work cross-platform
+
+### 9. Suppress Rules (src/utils/suppress.ts)
+
+Users can suppress individual issues by rule/path. Subtle bugs here cause either under-reporting (silently hiding real issues) or noisy false negatives.
+
+- Malformed suppress pattern (bad glob, unknown rule ID) — caught and warned, or crashes the run?
+- Glob matching uses forward slashes internally — do patterns defined by users get normalized before matching on Windows?
+- **Suppress-before-score-interaction**: if the runner produces the issue and the suppress filter removes it, does the category score reflect the filtered count? Or does the score use the raw count and the UI just hide? Whichever it is, behaviour must be documented and tested
+- Pathological patterns (`**/**/**`, regex-like input passed where globs expected) — don't crash the scan
+
+### 10. Report Privacy
+
+Reports are persisted (`.sickbay/last-report.json`), shared via `?report=<base64>` URLs, and uploaded to Anthropic when AI is enabled. Audit what leaks out.
+
+- **Absolute paths with usernames** — any runner embedding `/Users/alice/...` leaks operator identity. Every path in a report must come from `relativeFromRoot()`, never from raw `execa` stdout that retained absolute paths
+- **.env values** — the `secrets` runner should *detect* them but must not *include* the matched string in the report's issue message. Verify the output redacts the secret
+- **Environment variables** — grep for `process.env` in every integration. Any serialization of `process.env.*` into a report field is a leak
+- **Stack traces** — if a runner fails and stashes the error, the stack trace can contain absolute paths and sometimes environment context. Scrub before embedding
+
+### 11. Dep-Tree Generation (utils/dep-tree.ts)
+
+Core computes the dep tree by shelling to the package manager via `getDependencyTree()`. Disk caching lives in the CLI layer (see `/audit-cli` §9 for `.sickbay/dep-tree.json` handling) — this section covers only core's generator.
+
+- Package-manager output format differences — pnpm returns an array, npm/yarn return an object. Verify all three paths are exercised
+- `bun` is intentionally skipped (`ls --json` not parseable). If bun gains support, the skip should be revisited
+- `reject: false` + 30s timeout means silent failures produce an empty tree. Verify downstream consumers distinguish "no deps" from "generation failed" when that matters
+
+### 12. Test Coverage
 
 - Every runner in `src/integrations/` should have a corresponding `.test.ts`
+- Every advisor in `src/advisors/` should have a corresponding `.test.ts`
 - Check for runners with no tests or only smoke tests
-- Critical utils (`file-helpers.ts`, `detect-project.ts`, `detect-monorepo.ts`, `scoring.ts`) should have thorough unit tests
+- Critical utils (`file-helpers.ts`, `detect-project.ts`, `detect-monorepo.ts`, `scoring.ts`, `suppress.ts`, `dep-tree.ts`) should have thorough unit tests
+
+### 13. Snapshot Regression Suite
+
+`tests/snapshots/fixture-regression.test.ts` runs Sickbay against the `fixtures/` workspace and compares the JSON output to committed snapshots. After any change to a runner, advisor, or scoring:
+
+- Run `pnpm test:snapshots`
+- Intentional diffs get updated with `-u` and explained in the PR description
+- A snapshot diff in a fixture you didn't intend to affect is a leak — trace it before updating
 
 ## Key Files
 
 ```
 packages/core/src/
-├── runner.ts          # Orchestrator — check this for allSettled handling
-├── scoring.ts         # Weights and edge cases
-├── types.ts           # SickbayReport shape
-├── integrations/      # 34 runners — sample 5–10 for contract compliance
+├── runner.ts              # Orchestrator — check this for allSettled handling
+├── scoring.ts             # Weights and edge cases
+├── config.ts              # User TS config — trust boundary
+├── types.ts               # SickbayReport shape
+├── index.ts               # Public API — verify no internals leak
+├── integrations/          # 34 runners — sample 5–10 for contract compliance
+├── advisors/              # 4 best-practice advisors — parallel contract
 ├── utils/
-│   ├── file-helpers.ts      # relativeFromRoot — cross-platform critical
-│   ├── detect-project.ts    # Framework detection
-│   └── detect-monorepo.ts   # Monorepo detection
+│   ├── file-helpers.ts    # relativeFromRoot — cross-platform critical
+│   ├── detect-project.ts  # Framework detection
+│   ├── detect-monorepo.ts # Monorepo detection
+│   ├── suppress.ts        # Suppress rule evaluation
+│   └── dep-tree.ts        # Cached dep graph
+tests/snapshots/           # Cross-package regression suite
 ```
+
+## Output Format
+
+Dispatched reviewer should report findings as:
+
+```
+[Severity: High|Medium|Low] path/to/file.ts:123
+What's wrong: <one-line description>
+Why it matters: <impact on users or maintainers>
+Suggested fix: <concrete change>
+```
+
+Skip style/formatting issues — oxlint and oxfmt handle those.
 
 ## How to Run
 
-Dispatch a `feature-dev:code-reviewer` agent. Provide key files from the checklist above. Ask it to flag issues by severity — only report high-confidence findings.
+Dispatch a `feature-dev:code-reviewer` agent. Provide the checklist above and point it at the Key Files. Tell it to flag by severity and only report high-confidence findings.
+
+## Related Audits
+
+- Adding/removing a runtime dep in core → run **audit-cli** (bundled-deps mirror must update)
+- Changing report `types.ts` → run **audit-web** (type imports must still compile)
+- Adding a new file in a new directory → run **audit-architecture** (check pipeline/workspace registration)

--- a/.claude/skills/audit-web/SKILL.md
+++ b/.claude/skills/audit-web/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: audit-web
-description: Use when auditing apps/web for Node.js import violations, XSS in AI chat or report rendering, API key exposure, or report loading edge cases.
+description: Use when auditing apps/web for Node.js import violations, XSS in AI chat or report rendering, Anthropic SDK browser safety, API key exposure, CSP and cross-origin contract, report loading edge cases, or dashboard component issues. Run before merging any change that touches apps/web/.
 ---
 
 # Audit: apps/web
 
-The browser dashboard. The critical constraint: it must never import values from `sickbay-core` — that would bundle Node.js modules into the browser build.
+The browser dashboard. Critical constraints: never import values from `sickbay-core` (would bundle Node.js into browser), never leak the user's Anthropic API key, and never render user-controlled report data unsanitized.
 
 ## Checklist
 
@@ -20,70 +20,137 @@ The browser dashboard. The critical constraint: it must never import values from
 
 ### 2. XSS Surface
 
-The dashboard renders user-controlled data from the scan report (file paths, issue messages, dependency names, AI responses). Review for injection risks:
+The dashboard renders user-controlled data from the scan report (file paths, issue messages, dependency names, AI responses, config contents). Review every component that renders report data:
 
-- **AI chat (`ChatDrawer.tsx`)** — AI responses are rendered as text or markdown. Check for any raw HTML injection patterns (`innerHTML`, unsafe React props that bypass React's built-in escaping)
-- **Issue messages** — issue `message` strings from check runners could contain file paths with special characters. Verify these are rendered as text nodes, not raw HTML
-- **Dependency names** — rendered in `DependencyList.tsx` and `DependencyGraph.tsx`. Names are generally safe but verify no HTML is injected
+- **AI chat (`ChatDrawer.tsx`)** — AI responses rendered as text or markdown. Check for any use of React's raw-HTML escape-hatch prop, `innerHTML`, or any markdown renderer configured to allow raw HTML. Default React text nodes and a sanitizing markdown renderer are safe; anything else needs scrutiny
+- **Issue messages (`IssuesList.tsx`, `CriticalIssues.tsx`)** — `message` strings from check runners can contain file paths with special characters. Render as text nodes, not raw HTML
+- **Best practices (`BestPracticesDrawer.tsx`)** — advisor recommendations may be formatted as markdown. If so, the markdown renderer must strip raw HTML
+- **Config content (`ConfigTab.tsx`)** — displays the user's `sickbay.config.ts`. Should render inside a `<pre><code>` block; never interpolated into markup
+- **Dependency names (`DependencyList.tsx`, `DependencyGraph.tsx`)** — generally safe but verify no HTML is injected
 - **Report loading** — a malicious `?report=<base64>` URL param or `localStorage` entry could contain crafted data. Does the loader validate the report shape before rendering?
 
-### 3. AI / API Key Handling
+### 3. Anthropic SDK Browser Safety
+
+`@anthropic-ai/sdk` is bundled into the browser build. The user's `ANTHROPIC_API_KEY` becomes a client-side secret.
+
+- The SDK requires the "allow browser" flag — that's correct for this use case (the user provides their own key on their own machine). Verify the flag is scoped to this app and not being propagated elsewhere
+- All Anthropic traffic goes to `api.anthropic.com` only. Check the network panel during a chat session — no telemetry endpoints, no CDN callbacks, no log aggregators receiving request headers
+- No logging middleware, interceptors, or dev-tool extensions persist request headers (which contain the Authorization bearer)
+- The key is never written to `localStorage` or serialized into the report — it lives only in-memory for the session
+- Missing key: dashboard hides AI features entirely (no error toast, no "enter your key" prompt that could be phished)
+
+### 4. API Key Handling (Broader)
 
 Review `AISummary.tsx`, `ChatDrawer.tsx`:
 
-- Is `ANTHROPIC_API_KEY` ever logged, serialized into the report, or sent anywhere other than the Anthropic API?
-- Does the dashboard handle missing API key gracefully — hiding AI features rather than showing an error or blank?
-- Are AI responses that fail (network error, rate limit) surfaced clearly to the user?
+- `ANTHROPIC_API_KEY` is never logged, serialized into the report, or sent anywhere other than the Anthropic API
+- Dashboard handles missing API key gracefully — hides AI features rather than showing an error or blank
+- AI responses that fail (network error, rate limit) are surfaced clearly to the user
 - **Prompt injection** — the AI receives the full `SickbayReport` as context. A crafted project (e.g., a file with a name designed to manipulate the prompt) could attempt injection. Is the system prompt robust enough to resist this?
 
-### 4. Report Loading Edge Cases
+### 5. CSP and Cross-Origin Contract
+
+The CLI serves the dashboard from localhost. The dashboard then fetches `api.anthropic.com` directly.
+
+- Check `apps/web/index.html` for a Content-Security-Policy meta tag. If present, `connect-src` must allow `api.anthropic.com`
+- Check the CLI's web server response headers (cross-reference with **audit-cli**) — if a CSP header is set there, it must be compatible with loading the bundled JS and fetching the Anthropic API
+- The fetch to `/sickbay-report.json` is same-origin — no CORS surface. The fetch to Anthropic is cross-origin — ensure requests don't rely on cookies (they shouldn't; they use a bearer header)
+
+### 6. Report Loading Edge Cases
 
 Review `src/lib/load-report.ts`:
 
-- What happens when `/sickbay-report.json` returns a 404? (Normal when opening the dashboard standalone)
-- What happens when the JSON is malformed?
-- What happens when the report is structurally valid JSON but missing required fields (e.g., no `checks` array)?
-- Does `?report=<base64>` handle invalid base64 gracefully?
-- Is there a size limit on `localStorage`? A very large report could fail to persist
+- `/sickbay-report.json` returns a 404 → normal when opening the dashboard standalone; must render empty-state, not crash
+- JSON is malformed → caught, user-readable message, not white screen
+- Structurally valid JSON but missing required fields (e.g., no `checks` array) → validated; graceful fallback
+- `?report=<base64>` with invalid base64 → handled without throwing
+- Size limit on `localStorage` — a very large report can fail to persist. Silent truncation is worse than a message
 
-### 5. Monorepo Report Rendering
+### 7. Monorepo Report Rendering
 
 `MonorepoOverview.tsx` handles the multi-package report case.
 
-- Does it handle a monorepo report with zero packages gracefully?
-- Does it handle packages with identical names (shouldn't happen but worth checking)?
-- Are per-package scores computed correctly, or is there a risk of using the wrong package's data?
+- Handles a monorepo report with zero packages gracefully
+- Handles packages with identical names (shouldn't happen but worth checking)
+- Per-package scores computed correctly — no risk of using the wrong package's data
 
-### 6. Display Fidelity
+### 8. Display Fidelity
 
 When components parse check issues into UI state (outdated, unused, missing, duplicated, etc.), the display must source each value from the **same place** the signal came from. Mixing scanner-reported data with `projectInfo` fields produces misleading UI without any type error.
 
-- **`DependencyList.tsx` canonical case:** when a dep is outdated, the "current version" shown in the row should be the **installed** version parsed from the issue message (`from` in `"lodash: 4.0.0 → 4.17.21 (patch)"`), NOT the **declared range** from `report.projectInfo.dependencies` (`^4.0.0`). These can diverge in pnpm catalog drift, version overrides, stale lockfile resolutions, and workspace hoisting scenarios — producing rows like `^4.1.3 → 4.1.3` that look like bugs but are actually the UI lying about what the scanner found.
-- **General rule:** for every derived UI state, ask "what is the source of truth?" — the check issue itself is usually the answer, not `projectInfo`.
-- **Test construction:** for each derived state (outdated / unused / missing / etc.), construct a test where the declared range and the scanner's reported version differ, and assert the rendered cell shows the scanner value.
+- **`DependencyList.tsx` canonical case:** when a dep is outdated, the "current version" shown in the row must be the **installed** version parsed from the issue message (`from` in `"lodash: 4.0.0 → 4.17.21 (patch)"`), NOT the **declared range** from `report.projectInfo.dependencies` (`^4.0.0`). These diverge in pnpm catalog drift, version overrides, stale lockfile resolutions, and workspace hoisting scenarios — producing rows like `^4.1.3 → 4.1.3` that look like bugs but are actually the UI lying about what the scanner found
+- **General rule:** for every derived UI state, ask "what is the source of truth?" — the check issue itself is usually the answer, not `projectInfo`
+- **Test construction:** for each derived state (outdated / unused / missing / etc.), construct a test where the declared range and the scanner's reported version differ, and assert the rendered cell shows the scanner value
 
-### 7. Constants Drift
+### 9. Dependency Graph (`DependencyGraph.tsx`)
+
+Home-grown dep graph visualizations routinely look worse than dedicated tools and balloon bundle size.
+
+- Is this component a thin wrapper over a mature graph library, or a bespoke renderer? The latter tends to accumulate UX bugs (overlap, unreadable on large graphs, no search)
+- Performance on large monorepos — does it freeze the browser or the main thread? Any `useMemo` deps missing that recompute on every render?
+- If UX is clearly worse than a dedicated tool (e.g. Node Modules Inspector), consider linking out instead of maintaining in-house. Precedent: home-grown viz was replaced with an external link in a prior cycle
+
+### 10. Constants Drift
 
 `apps/web/src/lib/constants.ts` duplicates scoring constants from core to avoid Node.js imports.
 
 - Compare these values against `packages/core/src/constants.ts` and `packages/core/src/scoring.ts`
-- If they've drifted, the dashboard will display wrong colors or thresholds while the CLI shows correct values
+- If they've drifted, the dashboard displays wrong colors or thresholds while the CLI shows correct values
+- CI smoke test idea: a test that fails if the duplicated values diverge from core's values (read core's source via a build-time script, not a value import)
+
+### 11. Issue Grouping & Suppress Snippets (`lib/`)
+
+- `issue-grouping.ts` — grouping must be stable across renders. Same report in, same grouped output out — otherwise the UI thrashes when the report updates
+- `suppress-snippet.ts` — generates config snippets for user copy-paste. Rule IDs and paths in the snippet must be properly escaped (quoted strings, not raw interpolation)
+
+### 12. Additional Component Coverage
+
+Components not otherwise called out that render user-controlled data:
+
+- `About.tsx` — mostly static but check version strings
+- `HistoryChart.tsx` — numeric data only, but check tooltip formatting for injection
+- `CodebaseStats.tsx` — file counts, language breakdowns. Low risk, verify render paths
 
 ## Key Files
 
 ```
 apps/web/src/
 ├── lib/
-│   ├── constants.ts        # Duplicated from core — check for drift
-│   └── load-report.ts      # Report loading — edge case handling
+│   ├── constants.ts           # Duplicated from core — check for drift
+│   ├── load-report.ts         # Report loading — edge case handling
+│   ├── issue-grouping.ts      # Stable grouping
+│   └── suppress-snippet.ts    # Generated config snippets
 ├── components/
-│   ├── AISummary.tsx        # AI integration — key handling, prompt injection
-│   ├── ChatDrawer.tsx       # AI chat — XSS in rendered responses
-│   ├── DependencyList.tsx   # Renders user-controlled dep names
-│   ├── IssuesList.tsx       # Renders user-controlled issue messages
-│   └── MonorepoOverview.tsx # Multi-package report
+│   ├── AISummary.tsx          # AI integration — key handling, prompt injection
+│   ├── ChatDrawer.tsx         # AI chat — XSS in rendered responses
+│   ├── DependencyList.tsx     # Source-of-truth / display fidelity
+│   ├── DependencyGraph.tsx    # Home-grown viz — flag for replacement if bespoke
+│   ├── IssuesList.tsx         # User-controlled issue messages
+│   ├── CriticalIssues.tsx     # Same XSS surface as IssuesList
+│   ├── BestPracticesDrawer.tsx # Advisor recommendations
+│   ├── ConfigTab.tsx          # Renders user config — sanitize
+│   └── MonorepoOverview.tsx   # Multi-package report
 ```
+
+## Output Format
+
+Dispatched reviewer should report findings as:
+
+```
+[Severity: High|Medium|Low] path/to/file.tsx:123
+What's wrong: <one-line description>
+Why it matters: <impact on users or maintainers>
+Suggested fix: <concrete change>
+```
+
+Skip visual/styling issues entirely. Prioritize: import discipline → API key exposure → XSS → display fidelity → everything else.
 
 ## How to Run
 
-Dispatch a `feature-dev:code-reviewer` agent. Start with the import discipline check (grep for `from 'sickbay-core'`), then constants drift, then XSS surface. Skip visual/styling issues entirely.
+Dispatch a `feature-dev:code-reviewer` agent. First action: grep `apps/web/src/` for `from 'sickbay-core'` and flag any non-type imports. Then constants drift, then XSS surface across every component listed.
+
+## Related Audits
+
+- Changes that add `/` endpoints to the dashboard → cross-check **audit-cli** (web server) for CORS parity
+- Changes to `constants.ts` → verify matches against core (run **audit-core** side-by-side)
+- New component rendering report fields → consider XSS implications, verify source-of-truth rule

--- a/.claude/skills/prime/SKILL.md
+++ b/.claude/skills/prime/SKILL.md
@@ -36,13 +36,25 @@ Read based on the task at hand:
 - `packages/core/src/types.ts` — core interfaces (`SickbayReport`, `CheckResult`, `Issue`)
 - `packages/core/src/runner.ts` — main orchestrator
 - `packages/core/src/scoring.ts` — weighted scoring logic
-- `packages/core/src/integrations/` — individual check runners
+- `packages/core/src/config.ts` — user config (`sickbay.config.ts`) loading and validation
+- `packages/core/src/integrations/` — individual check runners (pass/fail signals)
+- `packages/core/src/advisors/` — best-practice advisors (recommendations, parallel to runners)
+- `packages/core/src/utils/suppress.ts` — suppress rule evaluation (affects which issues reach the report)
 
 **If working on terminal UI:**
 
 - `apps/cli/src/index.ts` — CLI entry, Commander setup
 - `apps/cli/src/components/App.tsx` — root Ink component, UI phases
-- `apps/cli/src/components/tui/` — TUI dashboard components
+- `apps/cli/src/components/tui/` — TUI dashboard components + hooks
+
+**If working on a specific subcommand:**
+
+- `apps/cli/src/commands/fix.ts` — **modifies user files** (highest-risk)
+- `apps/cli/src/commands/init.ts` — writes `sickbay.config.ts`
+- `apps/cli/src/commands/web.ts` — HTTP server for the `--web` dashboard
+- `apps/cli/src/commands/claude.ts` + `apps/cli/src/services/ai.ts` — CLI AI integration
+- `apps/cli/src/commands/doctor.ts` — environment diagnostics (largest subcommand)
+- `apps/cli/src/commands/{diff,stats,trend,badge}.ts` — report comparison and output formats
 
 **If working on web dashboard:**
 
@@ -56,6 +68,7 @@ Read based on the task at hand:
 - `packages/core/src/integrations/knip.test.ts` — pattern for testing a runner
 - `packages/core/src/integrations/base.test.ts` — pattern for testing base class
 - `apps/cli/src/components/QuickWins.test.tsx` — pattern for testing Ink components
+- `tests/snapshots/fixture-regression.test.ts` — cross-package snapshot regression suite; run via `pnpm test:snapshots` after any runner / advisor / scoring change
 
 **If working on documentation site:**
 
@@ -76,6 +89,17 @@ Check recent activity:
 
 Check current branch and status:
 !`git status`
+
+### 5. Before Merging
+
+Match the work to an audit skill and run it before committing:
+
+- `/audit-core` — any change under `packages/core/` (runners, advisors, scoring, config, suppress, dep-tree)
+- `/audit-cli` — any change under `apps/cli/` (subcommands — especially `fix`, TUI hooks, Commander setup, web server)
+- `/audit-web` — any change under `apps/web/` (components rendering report data, AI integration, constants drift)
+- `/audit-architecture` — cross-package changes, new packages, workspace / build-pipeline / release-config changes
+
+See `CLAUDE.md` → "Code Quality Audits" for the full trigger matrix.
 
 <!-- ## Output Report
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,12 @@ Four targeted audit skills cover the package boundaries. Run them when you ship 
 
 | Skill | When to run |
 | ----- | ----------- |
-| `/audit-core` | After adding/modifying a runner in `integrations/`, changing `runner.ts`, `scoring.ts`, or `types.ts`, or after a dependency update in core |
-| `/audit-cli` | After touching CLI flags, TUI hooks, or `commands/web.ts` |
-| `/audit-web` | After adding components that render report data, or modifying `load-report.ts` |
-| `/audit-architecture` | After merging a large cross-package branch, adding a new package, or before a major release |
+| `/audit-core` | After touching any runner in `integrations/`, any advisor in `advisors/`, `runner.ts`, `scoring.ts`, `types.ts`, `config.ts`, `utils/suppress.ts`, `utils/dep-tree.ts`, or bumping a core runtime dep |
+| `/audit-cli` | After touching any subcommand in `commands/` (especially `fix.ts` — it writes user files), `services/ai.ts`, TUI hooks, Commander setup, `lib/history.ts`, or `commands/web.ts` |
+| `/audit-web` | After adding/modifying any component that renders report data, changing `load-report.ts`, `lib/constants.ts`, the AI integration, or `DependencyGraph.tsx` |
+| `/audit-architecture` | After merging a large cross-package branch, adding a package, touching `turbo.json`, `pnpm-workspace.yaml`, `tsconfig.base.json`, `.releaserc.json`, or before a major release |
 
-Each skill dispatches a `feature-dev:code-reviewer` agent with a package-specific checklist. Fix findings before committing.
+Each skill dispatches a specialized reviewer agent (`feature-dev:code-reviewer` or `monorepo-architect`) with a package-specific checklist. Fix findings before committing.
 
 This document helps Claude Code understand the Sickbay codebase structure and where to look when making updates.
 
@@ -121,14 +121,17 @@ vi.mock('path', async () => {
   - Each extends `BaseRunner` and implements `run()` method
   - Universal: `knip.ts`, `npm-audit.ts`, `eslint.ts` (detects ESLint in the analyzed user project — distinct from sickbay's own oxlint tooling), `git.ts`, etc.
   - Framework-specific: `react-perf.ts`, `next-*.ts`, `angular-*.ts`, `node-*.ts`
-- `src/utils/` - Shared utilities (file detection, command execution, monorepo detection)
+- `src/advisors/` - Best-practice advisors (parallel to integrations — recommendations, not pass/fail). Four advisors: `react-best-practices.ts`, `next-best-practices.ts`, `angular-best-practices.ts`, `universal-best-practices.ts`; all extend `BaseAdvisor`
+- `src/utils/` - Shared utilities: `file-helpers.ts` (cross-platform paths — use `relativeFromRoot`), `detect-project.ts` (framework detection), `detect-monorepo.ts`, `suppress.ts` (rule suppression evaluation), `dep-tree.ts` (cached dep graph written to `.sickbay/dep-tree.json`)
 
 **When to modify**:
 
 - Adding new health checks → Create new runner in `src/integrations/`, register in `runner.ts`
+- Adding best-practice recommendations → Create advisor in `src/advisors/`, wire it up in the advisor registration flow
 - Changing scoring weights → Edit `src/scoring.ts`
 - Modifying report structure → Update `src/types.ts` (affects CLI and web)
 - Fixing check logic → Edit specific integration file
+- Changing config schema → Edit `src/config.ts` (user-authored `sickbay.config.ts` is the trust boundary)
 
 **Dependencies**: All external tools (knip, depcheck, madge, etc.) are bundled here.
 
@@ -146,7 +149,9 @@ vi.mock('path', async () => {
 - `src/components/CheckResult.tsx` - Individual check display (score bars, issues)
 - `src/components/Summary.tsx` - Overall score + issue counts
 - `src/components/QuickWins.tsx` - Top actionable fixes
-- `src/commands/web.ts` - HTTP server for `--web` flag (serves web dashboard)
+- `src/commands/` - Subcommand entries. Notable: `web.ts` (HTTP dashboard server), `fix.ts` (**modifies user files — highest-risk**), `init.ts` (writes `sickbay.config.ts`), `claude.ts` (CLI AI), `doctor.ts` (environment diagnostics, largest subcommand), plus `diff.ts`, `stats.ts`, `trend.ts`, `badge.ts`
+- `src/services/ai.ts` - AI client used by the `claude` subcommand
+- `src/lib/history.ts` - Trend history read/write for `.sickbay/history.json`
 
 **UI Phases**:
 
@@ -178,9 +183,14 @@ vi.mock('path', async () => {
 - `src/components/Dashboard.tsx` - Main layout (sidebar + tabbed content)
 - `src/components/ScoreCard.tsx` - Circular score displays per category
 - `src/components/IssuesList.tsx` - Filterable/sortable issues table
+- `src/components/CriticalIssues.tsx` - Collapsible critical-issues panel
+- `src/components/BestPracticesDrawer.tsx` - Advisor recommendations surfaced in the dashboard
 - `src/components/AISummary.tsx` - Claude-powered analysis drawer (if API key present)
 - `src/components/ChatDrawer.tsx` - Interactive AI chat interface
+- `src/components/ConfigTab.tsx` - Read-only display of user's `sickbay.config.ts`
+- `src/components/DependencyGraph.tsx` - Dependency visualization (review for bundle-size and UX tradeoffs)
 - `src/lib/load-report.ts` - Report loading logic (HTTP, query params, localStorage)
+- `src/lib/constants.ts` - Browser-safe duplicates of core's scoring constants
 
 **Report Loading Priority**:
 
@@ -297,10 +307,16 @@ packages/core/src/
 │   ├── angular-*.ts      # Angular-specific (7 runners)
 │   ├── node-*.ts         # Node.js-specific (3 runners)
 │   └── ...
+├── advisors/             # Best-practice recommendations (parallel to integrations)
+│   ├── base.ts           # BaseAdvisor abstract class
+│   ├── react-best-practices.ts, next-best-practices.ts
+│   ├── angular-best-practices.ts, universal-best-practices.ts
 └── utils/                # Shared helpers
     ├── detect-project.ts # Framework/runtime detection
     ├── detect-monorepo.ts # Monorepo detection
-    ├── file-helpers.ts   # File utilities
+    ├── file-helpers.ts   # Cross-platform path utilities (relativeFromRoot)
+    ├── suppress.ts       # Suppress rule evaluation
+    ├── dep-tree.ts       # Cached dep graph
     └── ...
 ```
 
@@ -317,10 +333,20 @@ apps/cli/src/
 │       ├── HealthPanel.tsx, ScorePanel.tsx, TrendPanel.tsx, ...
 │       └── hooks/        # useFileWatcher, useGitStatus, useSickbayRunner, ...
 ├── commands/             # Subcommand implementations
-│   ├── web.ts, fix.ts, diff.ts, badge.ts, trend.ts, stats.ts, doctor.ts, init.ts
+│   ├── web.ts            # HTTP dashboard server
+│   ├── fix.ts            # Writes user files — highest-risk subcommand
+│   ├── init.ts           # Writes sickbay.config.ts
+│   ├── claude.ts         # CLI AI (uses services/ai.ts)
+│   ├── doctor.ts         # Environment diagnostics (largest)
+│   └── diff.ts, badge.ts, trend.ts, stats.ts
+├── services/
+│   └── ai.ts             # AI client for the claude subcommand
 └── lib/                  # Shared utilities
     ├── history.ts        # Trend history read/write
-    └── update-check.ts   # npm update notifications
+    ├── update-check.ts   # npm update notifications
+    ├── issue-grouping.ts # Stable issue grouping
+    ├── resolve-package.ts
+    └── project-hash.ts
 ```
 
 ### Web Package Structure
@@ -333,15 +359,20 @@ apps/web/src/
 ├── components/           # React components
 │   ├── Dashboard.tsx     # Main layout (sidebar + tabbed content)
 │   ├── ScoreCard.tsx, IssuesList.tsx, DependencyList.tsx, CodebaseStats.tsx
+│   ├── CriticalIssues.tsx      # Collapsible critical-issues panel
+│   ├── BestPracticesDrawer.tsx # Advisor recommendations
 │   ├── AISummary.tsx     # AI insights drawer
 │   ├── ChatDrawer.tsx    # Interactive AI chat
 │   ├── HistoryChart.tsx  # Score trend visualization
-│   ├── MonorepoOverview.tsx  # Monorepo scoreboard + cross-package view
+│   ├── MonorepoOverview.tsx    # Monorepo scoreboard + cross-package view
 │   ├── ConfigTab.tsx     # Read-only config display
+│   ├── DependencyGraph.tsx     # Dependency visualization
 │   └── ...
 └── lib/
     ├── load-report.ts    # Report fetching
-    └── constants.ts      # Duplicated core constants (browser-safe)
+    ├── constants.ts      # Duplicated core constants (browser-safe)
+    ├── issue-grouping.ts # Display-side grouping stability
+    └── suppress-snippet.ts # Generated suppress config snippets
 ```
 
 ---
@@ -466,5 +497,9 @@ node apps/cli/dist/index.js --path ~/Desktop/test-app
 ### If adding CLI options:
 
 → Edit `apps/cli/src/index.ts`
+
+### Before merging:
+
+→ Run the matching audit skill (`/audit-core`, `/audit-cli`, `/audit-web`, or `/audit-architecture` for cross-cutting changes). See the Code Quality Audits table above for specific triggers.
 
 Run `/prime` for full project context (stack, architecture, file locations, domain model, gotchas).

--- a/packages/core/src/integrations/secrets.ts
+++ b/packages/core/src/integrations/secrets.ts
@@ -68,7 +68,6 @@ interface Finding {
   file: string;
   line: number;
   pattern: string;
-  codeSnippet?: string;
 }
 
 export class SecretsRunner extends BaseRunner {
@@ -130,12 +129,6 @@ export class SecretsRunner extends BaseRunner {
         file: f.file,
         fix: {
           description: 'Move secrets to environment variables',
-          codeChange: f.codeSnippet
-            ? {
-                before: f.codeSnippet,
-                after: 'Use process.env.YOUR_SECRET_NAME instead',
-              }
-            : undefined,
         },
         reportedBy: ['secrets'],
       }));
@@ -271,7 +264,6 @@ function scanFile(filePath: string, projectRoot: string): Finding[] {
             file: relPath,
             line: i + 1,
             pattern: pattern.name,
-            codeSnippet: line.trim(),
           });
           break; // one finding per line
         }

--- a/packages/core/src/utils/suppress.test.ts
+++ b/packages/core/src/utils/suppress.test.ts
@@ -47,6 +47,22 @@ describe('applySuppression', () => {
     expect(result.suppressedCount).toBe(1);
   });
 
+  it('matches POSIX-style path rules against issues with Windows-style backslash paths', () => {
+    // Integrations that emit paths directly from tool output (e.g. knip on Windows)
+    // produce backslash separators. Users write suppress rules with forward slashes.
+    // Both must match.
+    const issues = [
+      issue('error in generated', 'src\\generated\\types.ts'),
+      issue('error in app', 'src\\app\\main.ts'),
+    ];
+    const result = applySuppression(issues, [
+      { path: 'src/generated/**', reason: 'auto-generated' },
+    ]);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].file).toBe('src\\app\\main.ts');
+    expect(result.suppressedCount).toBe(1);
+  });
+
   it('suppresses issues matching a message substring (case-insensitive)', () => {
     const issues = [
       issue('NEXT_PUBLIC_API_KEY found in config'),

--- a/packages/core/src/utils/suppress.ts
+++ b/packages/core/src/utils/suppress.ts
@@ -66,8 +66,15 @@ export function applySuppression(issues: Issue[], rules: SuppressionRule[]): Sup
 
   let suppressedCount = 0;
   const kept = issues.filter((issue) => {
+    // Normalize backslashes so rules written with POSIX globs match paths
+    // that Windows integrations emit with `\` separators.
+    const normalizedFile = issue.file?.replace(/\\/g, '/');
     const suppressed = compiled.some((rule) => {
-      const pathOk = rule.pathMatch ? (issue.file ? rule.pathMatch(issue.file) : false) : true;
+      const pathOk = rule.pathMatch
+        ? normalizedFile
+          ? rule.pathMatch(normalizedFile)
+          : false
+        : true;
       const matchOk = rule.match ? issue.message.toLowerCase().includes(rule.match) : true;
       return pathOk && matchOk;
     });


### PR DESCRIPTION
## Summary

- **Buffed the four audit skills** (`/audit-core`, `/audit-cli`, `/audit-web`, `/audit-architecture`) + `/prime` + `CLAUDE.md` from surface-level checklists to depth-oriented reviews. Covers subsystems previously invisible to the audits: advisors, config safety, suppress rules, every CLI subcommand individually (with `fix.ts` flagged highest-risk), Anthropic SDK browser safety, fixtures/docs isolation, tsconfig drift, and a new War Stories section documenting past architectural failures.
- **Fixed two privacy/correctness bugs uncovered by running `/audit-core` against `main`:**
  - `secrets.ts` was embedding the raw matched source line into `fix.codeChange.before`, which then traveled through shared reports (`?report=<base64>` URLs) and Anthropic uploads. A runner meant to *detect* secrets was *redistributing* them.
  - `suppress.ts` didn't normalize path separators before picomatch, so POSIX-style suppress rules silently failed to match on Windows for integrations emitting backslash paths (e.g. knip).
- **Added regression test** for the Windows suppress-rule fix (Linux CI wouldn't have caught it).

## Deferred

- `runner.ts:263` leaks the absolute `projectPath` into `SickbayReport`. The field is load-bearing at runtime (`history.ts` and `web.ts` use it to locate `.sickbay/`), so a proper fix needs to strip at serialize-time rather than in-place sanitization. Being tracked as a follow-up ticket.

## Test plan

- [x] `pnpm --filter sickbay-core typecheck` — clean
- [x] `pnpm --filter sickbay typecheck` — clean
- [x] `pnpm --filter sickbay-web typecheck` — clean
- [x] `pnpm --filter sickbay-core test` — 788 passing (+1 new regression test)
- [x] `pnpm test:snapshots` — 95 passing (secrets schema change didn't break any fixture snapshots)
- [ ] CI matrix (Linux + Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)